### PR TITLE
set ip and pasv port range, detailed logging, close connections properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@ THE SOFTWARE.
         color: '#f37a33',
         defaults: {
             name: {value: ''},
-            port: {value: 7021}
+            ip: {value: ''},
+            port: {value: 7021},
+            passiveportrange: {value: ''}
         },
         credentials: {
             username: {type: 'text'},
@@ -51,6 +53,10 @@ THE SOFTWARE.
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
+        <label for="node-input-ip"><i class="icon-tag"></i>IP</label>
+        <input type="text" id="node-input-ip" placeholder="auto-detect">
+    </div>
+    <div class="form-row">
         <label for="node-input-port"><i class="icon-tag"></i>Port</label>
         <input type="number" id="node-input-port" placeholder="">
     </div>
@@ -61,6 +67,10 @@ THE SOFTWARE.
     <div class="form-row">
         <label for="node-input-password"><i class="icon-tag"></i>Password</label>
         <input type="password" id="node-input-password" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-passiveportrange"><i class="icon-tag"></i>Passive Mode Port Range</label>
+        <input type="text" id="node-input-passiveportrange" placeholder="random">
     </div>
 </script>
 


### PR DESCRIPTION
This PR allows to manually override the ip and passive port range which makes it possible to run this in a docker container.
It also includes the lftp library in the logging to make it easier to debug connection problems.
The third thing this PR does is to properly close connections. Before the passive data connections just stayed open and the ports stayed blocked.